### PR TITLE
Annotations being incorrectly flattened

### DIFF
--- a/fastapi_decorators/decorators.py
+++ b/fastapi_decorators/decorators.py
@@ -64,6 +64,7 @@ def depends(*args: Any, **kwargs: Any) -> Decorator:
             original_func,
             globalns=original_func.__globals__,
             localns=None,
+            include_extras=True,
         )
 
         resolved_params: dict[str, Parameter] = {}

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,7 +1,7 @@
 from functools import wraps
 import logging
 from time import sleep, time
-from typing import Any
+from typing import Annotated, Any
 from fastapi import Depends, FastAPI, HTTPException, Header, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -332,6 +332,17 @@ def may_fail_operation(should_fail: bool = False) -> dict[str, Any]:
 @app.get("/error-log")
 def get_error_log() -> list[Any]:
     return error_log
+
+
+@app.get("/headers")
+@log
+def expects_header(
+    requestor_id: Annotated[str, Header(alias="requestor_id")],
+) -> dict[str, str]:
+    """
+    Endpoint that returns current annotated requestor_id.
+    """
+    return {"requestor_id": requestor_id}
 
 
 if __name__ == "__main__":

--- a/tests/forwardrefs/test_forwardrefs.py
+++ b/tests/forwardrefs/test_forwardrefs.py
@@ -1,10 +1,10 @@
 """This app JUST tests forward references."""
 
 from __future__ import annotations
-
+from typing import Annotated
 
 import pytest
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Header
 from fastapi.testclient import TestClient
 
 from tests.forwardrefs.dummy_decorator import empty_decorator
@@ -32,5 +32,23 @@ def test_forward_references_are_copied_from_call_site_scope(
     test_client: TestClient,
 ) -> None:
     response = test_client.get("/test")
+    assert response.status_code == 200
+    assert response.json() == "OK"
+
+
+def test_forward_references_plus_annotation(
+    test_client: TestClient,
+) -> None:
+    @test_client.app.get("/test-extra")
+    @empty_decorator
+    def endpoint_with_request_dependency(
+        request: Request,
+        requestor_id: Annotated[str, Header(alias="requestor_id")],
+    ) -> str:
+        """Test a builtin."""
+        return "OK"
+
+    headers = {"requestor_id": "potato@me"}
+    response = test_client.get("/test-extra", headers=headers)
     assert response.status_code == 200
     assert response.json() == "OK"

--- a/tests/forwardrefs/test_forwardrefs.py
+++ b/tests/forwardrefs/test_forwardrefs.py
@@ -39,7 +39,7 @@ def test_forward_references_are_copied_from_call_site_scope(
 def test_forward_references_plus_annotation(
     test_client: TestClient,
 ) -> None:
-    @test_client.app.get("/test-extra")
+    @test_client.app.get("/test-extra")  # type: ignore[attr-defined,misc]
     @empty_decorator
     def endpoint_with_request_dependency(
         request: Request,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,3 +161,10 @@ def test_error_log_endpoint() -> None:
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
+
+
+def test_expects_header() -> None:
+    headers = {"requestor_id": "potato@me"}
+    response = client.get("/headers", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == headers


### PR DESCRIPTION
As above, for now this just raises the behavior. I don't think there's any special cases that trigger this, it seems to be everywhere.  Replicates the bug in #10.